### PR TITLE
feat: 감정 등록/수정 API 안정성 개선 및 S3 연동 오류 수정

### DIFF
--- a/src/main/java/com/melog/melog/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/melog/melog/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.melog.melog.common.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,18 +15,7 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException e) {
-        log.error("IllegalArgumentException: {}", e.getMessage());
-        
-        Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("timestamp", LocalDateTime.now());
-        errorResponse.put("status", HttpStatus.BAD_REQUEST.value());
-        errorResponse.put("error", "Bad Request");
-        errorResponse.put("message", e.getMessage());
-        
-        return ResponseEntity.badRequest().body(errorResponse);
-    }
+
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> handleGenericException(Exception e) {
@@ -51,5 +41,31 @@ public class GlobalExceptionHandler {
         errorResponse.put("message", e.getMessage());
         
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Map<String, Object>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.error("JSON 파싱 에러: {}", e.getMessage(), e);
+        
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("timestamp", LocalDateTime.now());
+        errorResponse.put("status", HttpStatus.BAD_REQUEST.value());
+        errorResponse.put("error", "Bad Request");
+        errorResponse.put("message", "요청 데이터 형식이 올바르지 않습니다: " + e.getMessage());
+        
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("잘못된 요청: {}", e.getMessage(), e);
+        
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("timestamp", LocalDateTime.now());
+        errorResponse.put("status", HttpStatus.BAD_REQUEST.value());
+        errorResponse.put("error", "Bad Request");
+        errorResponse.put("message", e.getMessage());
+        
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 } 

--- a/src/main/java/com/melog/melog/emotion/domain/EmotionType.java
+++ b/src/main/java/com/melog/melog/emotion/domain/EmotionType.java
@@ -1,5 +1,8 @@
 package com.melog.melog.emotion.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum EmotionType {
     JOY("기쁨"),
     EXCITEMENT("설렘"),
@@ -14,7 +17,26 @@ public enum EmotionType {
         this.description = description;
     }
 
+    @JsonValue
     public String getDescription() {
         return description;
+    }
+
+    @JsonCreator
+    public static EmotionType fromDescription(String description) {
+        if (description == null) {
+            return CALMNESS; // 기본값
+        }
+        
+        String normalizedDescription = description.trim();
+        
+        for (EmotionType emotionType : values()) {
+            if (emotionType.description.equals(normalizedDescription)) {
+                return emotionType;
+            }
+        }
+        
+        // 매칭되지 않는 경우 기본값 반환
+        return CALMNESS;
     }
 } 

--- a/src/main/java/com/melog/melog/emotion/domain/model/request/EmotionRecordSelectRequest.java
+++ b/src/main/java/com/melog/melog/emotion/domain/model/request/EmotionRecordSelectRequest.java
@@ -30,19 +30,8 @@ public class EmotionRecordSelectRequest {
         }
         
         private EmotionType findEmotionTypeByName(String emotionName) {
-            if (emotionName == null) return null;
-            
-            String normalizedName = emotionName.trim();
-            
-            // 정확한 매칭 시도
-            for (EmotionType emotionType : EmotionType.values()) {
-                if (emotionType.getDescription().equals(normalizedName)) {
-                    return emotionType;
-                }
-            }
-            
-            // 기본값 반환 (에러 대신)
-            return EmotionType.CALMNESS;
+            // Jackson이 자동으로 처리하므로 단순화
+            return emotionName != null ? EmotionType.fromDescription(emotionName) : EmotionType.CALMNESS;
         }
     }
 } 


### PR DESCRIPTION
- 감정 등록/수정 API JSON 파싱 에러 해결
  - EmotionType enum에 Jackson 어노테이션 추가
  - 한글 감정명 매핑 지원 (@JsonCreator, @JsonValue)
  - 기본값 반환으로 500 에러 방지

- S3 연동 오류 수정
  - S3Config를 dev/prod 프로파일 모두 지원
  - Ncloud Object Storage 호환성 설정 추가
  - 서명 방식 및 청크 인코딩 최적화

- API 안정성 및 에러 처리 개선
  - 트랜잭션 롤백 강화 (rollbackFor = Exception.class)
  - 음성 파일 유효성 검증 로직 추가
  - GlobalExceptionHandler에 JSON 파싱 에러 처리 추가

- 로컬 폴백 없이 S3 업로드 안정화
- 짧은 음성파일 및 잘못된 형식 파일 차단