### PR TITLE
feat: 감정 API 안정성 개선 및 S3 연동 오류 수정

### DIFF
--- a/src/main/java/com/melog/melog/emotion/application/service/EmotionRecordCreationService.java
+++ b/src/main/java/com/melog/melog/emotion/application/service/EmotionRecordCreationService.java
@@ -377,6 +377,22 @@ public class EmotionRecordCreationService {
     }
 
     /**
+     * 파일명에서 확장자를 추출합니다.
+     */
+    private String getFileExtension(String filename) {
+        if (filename == null || filename.isEmpty()) {
+            return "";
+        }
+        
+        int lastDotIndex = filename.lastIndexOf('.');
+        if (lastDotIndex == -1 || lastDotIndex == filename.length() - 1) {
+            return "";
+        }
+        
+        return filename.substring(lastDotIndex + 1);
+    }
+
+    /**
      * 한글 감정명을 EmotionType enum으로 변환합니다.
      */
     private EmotionType convertToEmotionType(String emotionName) {

--- a/src/main/java/com/melog/melog/emotion/application/service/EmotionRecordManagementService.java
+++ b/src/main/java/com/melog/melog/emotion/application/service/EmotionRecordManagementService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -23,6 +24,7 @@ public class EmotionRecordManagementService {
     private final EmotionRecordPersistencePort emotionRecordPersistencePort;
     private final EmotionScorePersistencePort emotionScorePersistencePort;
     private final EmotionCommentPersistencePort emotionCommentPersistencePort;
+    private final EmotionRecordQueryService emotionRecordQueryService;
 
     /**
      * 감정 선택을 업데이트합니다.
@@ -100,7 +102,13 @@ public class EmotionRecordManagementService {
             log.error("주요 감정 코멘트 매핑 실패: error={}", e.getMessage(), e);
         }
 
-        return null; // 실제로는 EmotionRecordResponse를 반환해야 하지만, 여기서는 null 반환
+        // 업데이트된 감정 기록을 다시 조회하여 응답 생성
+        EmotionRecord updatedRecord = emotionRecordPersistencePort.findById(recordId)
+                .orElseThrow(() -> new IllegalArgumentException("업데이트된 감정 기록을 찾을 수 없습니다: " + recordId));
+        
+        // 기존 감정 기록 정보를 그대로 사용하여 응답 생성
+        // emotions는 이미 위에서 수정했으므로 DB에서 최신 정보 조회
+        return emotionRecordQueryService.getEmotionRecord(nickname, recordId);
     }
 
     /**
@@ -116,9 +124,11 @@ public class EmotionRecordManagementService {
                 .orElseThrow(() -> new IllegalArgumentException("감정 기록을 찾을 수 없습니다: " + recordId));
 
         record.updateRecord(request.getText(), null);
-        EmotionRecord updatedRecord = emotionRecordPersistencePort.save(record);
+        emotionRecordPersistencePort.save(record);
 
-        return null; // 실제로는 EmotionRecordResponse를 반환해야 하지만, 여기서는 null 반환
+        // 기존 감정 기록 정보를 그대로 사용하여 응답 생성
+        // text만 수정했으므로 DB에서 최신 정보 조회
+        return emotionRecordQueryService.getEmotionRecord(nickname, recordId);
     }
 
     /**


### PR DESCRIPTION
- 감정 등록/수정 API JSON 파싱 에러 해결
  - EmotionType enum에 Jackson 어노테이션 추가
  - 한글 감정명 매핑 지원 (@JsonCreator, @JsonValue)
  - 기본값 반환으로 500 에러 방지

- S3 연동 오류 수정
  - S3Config를 dev/prod 프로파일 모두 지원
  - Ncloud Object Storage 호환성 설정 추가
  - 서명 방식 및 청크 인코딩 최적화

- API 안정성 및 에러 처리 개선
  - 트랜잭션 롤백 강화 (rollbackFor = Exception.class)
  - 음성 파일 유효성 검증 로직 추가
  - GlobalExceptionHandler에 JSON 파싱 에러 처리 추가
  - 감정 수정 API 응답 문제 해결 (null 반환 → 완전한 응답)

- 로컬 폴백 유지하면서 S3 업로드 안정화
- 짧은 음성파일 및 잘못된 형식 파일 차단