### PR TITLE
🔧 SSL 인증서 경로 문제 해결: Docker 볼륨 마운트 최적화

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,13 +38,16 @@ services:
       NCLOUD_S3_ENDPOINT: ${NCLOUD_S3_ENDPOINT}
       NCLOUD_S3_REGION: ${NCLOUD_S3_REGION}
       NCLOUD_S3_BUCKET: ${NCLOUD_S3_BUCKET}
+      # SSL 인증서 경로 설정
+      SSL_CERT_PATH: /etc/ssl/live/melog508.duckdns.org/fullchain.pem
+      SSL_KEY_PATH: /etc/ssl/live/melog508.duckdns.org/privkey.pem
 
 
     ports:
       - "443:443"  # HTTPS 포트
     user: "0:0"  # root 권한으로 실행 (권한 문제 해결)
     volumes:
-      - /etc/letsencrypt:/etc/letsencrypt:ro  # SSL 인증서 읽기 전용 마운트
+      - /etc/letsencrypt:/etc/ssl:ro  # SSL 인증서를 컨테이너 내부 경로로 마운트
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -54,8 +54,8 @@ server:
   port: 443
   ssl:
     enabled: true
-    certificate: /etc/letsencrypt/live/melog508.duckdns.org/fullchain.pem
-    certificate-private-key: /etc/letsencrypt/live/melog508.duckdns.org/privkey.pem
+    certificate: ${SSL_CERT_PATH:/etc/ssl/live/melog508.duckdns.org/fullchain.pem}
+    certificate-private-key: ${SSL_KEY_PATH:/etc/ssl/live/melog508.duckdns.org/privkey.pem}
   http2:
     enabled: true
   error:


### PR DESCRIPTION
- SSL 인증서를 컨테이너 내부 경로(/etc/ssl)로 마운트
- Spring Boot SSL 설정에 환경변수 기본값 적용
- CodeSpace Docker 환경에서 SSL 인증서 접근 문제 해결
- GitHub Secrets 추가 없이 자동 경로 매핑