### PR TITLE
🔧 SSL 인증서 경로 문제 완전 해결: Let's Encrypt 표준 경로 적용

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -47,7 +47,7 @@ services:
       - "443:443"  # HTTPS 포트
     user: "0:0"  # root 권한으로 실행 (권한 문제 해결)
     volumes:
-      - /etc/letsencrypt:/etc/ssl:ro  # SSL 인증서를 컨테이너 내부 경로로 마운트
+      - /etc/letsencrypt:/etc/letsencrypt:ro  # SSL 인증서 전체 디렉터리 마운트
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -54,8 +54,8 @@ server:
   port: 443
   ssl:
     enabled: true
-    certificate: ${SSL_CERT_PATH:/etc/ssl/live/melog508.duckdns.org/fullchain.pem}
-    certificate-private-key: ${SSL_KEY_PATH:/etc/ssl/live/melog508.duckdns.org/privkey.pem}
+    certificate: /etc/letsencrypt/live/melog508.duckdns.org/fullchain.pem
+    certificate-private-key: /etc/letsencrypt/live/melog508.duckdns.org/privkey.pem
   http2:
     enabled: true
   error:


### PR DESCRIPTION
- SSL 인증서 경로를 /etc/ssl → /etc/letsencrypt로 수정
- 볼륨 마운트를 전체 디렉터리로 변경 (심볼릭 링크 보존)
- Let's Encrypt 표준 경로 구조 준수
- 불필요한 환경변수 제거로 설정 단순화