### PR TITLE
🔒 SSL 인증서 문제 완벽 해결: Spring Boot 3.x PEM 번들 설정 적용

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,9 +38,9 @@ services:
       NCLOUD_S3_ENDPOINT: ${NCLOUD_S3_ENDPOINT}
       NCLOUD_S3_REGION: ${NCLOUD_S3_REGION}
       NCLOUD_S3_BUCKET: ${NCLOUD_S3_BUCKET}
-      # SSL 인증서 경로 설정
-      SSL_CERT_PATH: /etc/ssl/live/melog508.duckdns.org/fullchain.pem
-      SSL_KEY_PATH: /etc/ssl/live/melog508.duckdns.org/privkey.pem
+      # SSL 인증서 설정
+      DOMAIN_NAME: melog508.duckdns.org
+      SERVER_PORT: 443
 
 
     ports:
@@ -50,7 +50,7 @@ services:
       - /etc/letsencrypt:/etc/letsencrypt:ro  # SSL 인증서 전체 디렉터리 마운트
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      test: ["CMD", "curl", "-fsS", "-k", "https://localhost/actuator/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -51,13 +51,17 @@ management:
       show-details: when-authorized
 
 server:
-  port: 443
+  port: ${SERVER_PORT:443}
   ssl:
-    enabled: true
-    certificate: /etc/letsencrypt/live/melog508.duckdns.org/fullchain.pem
-    certificate-private-key: /etc/letsencrypt/live/melog508.duckdns.org/privkey.pem
-  http2:
-    enabled: true
+    bundle: app-cert
+
+spring:
+  ssl:
+    bundle:
+      pem:
+        app-cert:
+          certificate: /etc/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem
+          private-key: /etc/letsencrypt/live/${DOMAIN_NAME}/privkey.pem
   error:
     include-stacktrace: never
     include-message: always


### PR DESCRIPTION
- SSL 인증서 경로를 /etc/letsencrypt/live/<도메인>/로 통일
- JKS/P12 제거하고 PEM 전용 설정으로 변경
- Spring Boot 3.x SSL 번들 설정 적용
- 환경변수 DOMAIN_NAME, SERVER_PORT 주입
- 컨테이너 내부 SSL 인증서 상세 검사 로직 추가
- HTTPS 헬스체크로 변경