### PR TITLE
🔐 SSL 설정 완전 수정 및 권한 문제 해결

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,11 +60,7 @@ services:
       # SSL 인증서 설정
       DOMAIN_NAME: melog508.duckdns.org
       SERVER_PORT: 443
-      SERVER_SSL_BUNDLE: app-cert
-      SPRING_SSL_BUNDLE_PEM_APP_CERT_CERTIFICATE: /etc/letsencrypt/live/melog508.duckdns.org/fullchain.pem
-      SPRING_SSL_BUNDLE_PEM_APP_CERT_PRIVATE_KEY: /etc/letsencrypt/live/melog508.duckdns.org/privkey.pem
-      SSL_CERT_PATH: /etc/letsencrypt/live/melog508.duckdns.org/fullchain.pem
-      SSL_KEY_PATH: /etc/letsencrypt/live/melog508.duckdns.org/privkey.pem
+      SSL_KEY_STORE_PASSWORD: ${SSL_KEY_STORE_PASSWORD}
     ports:
       - "443:443"  # HTTPS 포트
     user: "0:0"  # root 권한으로 실행 (권한 문제 해결)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -82,7 +82,7 @@ echo "✅ 80 포트 비움 완료"
 # 3) SSL 인증서 발급 또는 갱신
 echo "🔐 SSL 인증서 처리 중..."
 
-# 호스트에서 직접 certbot 실행 (권한 문제 해결)
+# 호스트에서 직접 certbot 실행
 if command -v certbot >/dev/null 2>&1; then
     echo "🔧 호스트 certbot 사용..."
     
@@ -216,7 +216,7 @@ if [ -f "/etc/letsencrypt/live/$DOMAIN_NAME/keystore.p12" ]; then
 else
     echo "❌ PKCS12 키스토어를 찾을 수 없습니다!"
     echo "💡 수동으로 PKCS12 키스토어를 생성해주세요:"
-    echo "   sudo openssl pkcs12 -export \\"
+    echo "   openssl pkcs12 -export \\"
     echo "     -in /etc/letsencrypt/live/$DOMAIN_NAME/fullchain.pem \\"
     echo "     -inkey /etc/letsencrypt/live/$DOMAIN_NAME/privkey.pem \\"
     echo "     -out /etc/letsencrypt/live/$DOMAIN_NAME/keystore.p12 \\"


### PR DESCRIPTION
## 주요 변경사항

### 1. SSL 설정 방식 변경
- ❌ SSL Bundle 방식 제거 (app-cert 번들 문제)
- ✅ 전통적인 SSL 설정 방식으로 변경 (key-store)
- �� PEM 파일을 PKCS12 키스토어로 변환하여 Spring Boot 호환성 확보

### 2. 파일 경로 수정
- 📁 정확한 경로: /etc/letsencrypt/live/melog508.duckdns.org/keystore.p12
- 🗂️ application-prod.yml에서 하드코딩된 경로 사용
- �� docker-compose.prod.yml에서 불필요한 경로 환경변수 제거

### 3. 권한 문제 해결
- �� 일반 사용자(melog-app)가 /etc/letsencrypt/live/ 접근 불가 문제
- 🔑 서버에서 직접 권한 조정: chmod 755, chown melog-app:melog-app
- ✅ PKCS12 키스토어 파일 권한: 644 (일반 사용자 읽기 가능)

### 4. 배포 스크립트 정리
- �� sudo certbot 명령어 제거 (권한 문제 해결됨)
- ��️ 권한 조정 코드 제거 (서버에서 이미 완료)
- 📋 PKCS12 키스토어 확인 로직 단순화

### 5. Docker 설정 최적화
- �� Dockerfile.prod 생성 (HTTPS 포트 443 노출)
- 🔒 컨테이너 root 권한 설정 (user: 0:0)
- 📦 SSL 인증서 볼륨 마운트: /etc/letsencrypt:/etc/letsencrypt:ro

## 해결된 문제들
- ✅ SSL bundle name 'app-cert' cannot be found
- ✅ PEM KeyStore not available
- ✅ Permission denied: /etc/letsencrypt/live/
- ✅ SSL 인증서 파일 경로 불일치

## 현재 상태
- �� SSL 인증서: Let's Encrypt에서 정상 발급 완료
- �� PKCS12 키스토어: 정상 생성 및 권한 설정 완료
- �� Spring Boot: HTTPS 서버 기동 준비 완료

## 다음 단계
- 배포 스크립트 실행하여 HTTPS 서버 정상 기동 확인